### PR TITLE
Fix issues #1 and #2

### DIFF
--- a/src/Arrow.Avalonia/Controls/Arrow.axaml.cs
+++ b/src/Arrow.Avalonia/Controls/Arrow.axaml.cs
@@ -130,7 +130,7 @@ public partial class Arrow : UserControl
         AvaloniaProperty.Register<Arrow, bool>(nameof(IsVisible), defaultValue: true);
 
     public static readonly StyledProperty<bool> IsProportionalProperty =
-      AvaloniaProperty.Register<Arrow, bool>(nameof(IsProportional), true);
+      AvaloniaProperty.Register<Arrow, bool>(nameof(IsProportional), false);
 
     public static readonly StyledProperty<bool> IsFilledProperty =
         AvaloniaProperty.Register<Arrow, bool>(nameof(IsFilled), false);
@@ -230,7 +230,7 @@ public partial class Arrow : UserControl
         var start = s.StartPoint;
         var end = s._endPoint;
         var len = s.IsProportional || !s.HeadLength.HasValue() ? GetProportionalHeadLength.Execute(start, end) : s.HeadLength;
-        var width = s.IsProportional || !s.HeadLength.HasValue() ? GetProportionalHeadWidth.Execute(start, end) : s.HeadWidth;
+        var width = s.IsProportional || !s.HeadWidth.HasValue() ? GetProportionalHeadWidth.Execute(start, end) : s.HeadWidth;
 
         var headPoints = GetHeadPoints.Execute(new(new(start, end, len, width))).HeadPoints;
         if (headPoints is null)


### PR DESCRIPTION
This PR addresses and resolves the issues described in #1 and #2.

### Changes:
- `IsProportional `Property Update:
Fixed the behavior where setting `IsProportional` to false still updated the `HeadLength` and `HeadWidth` properties. 
Now, these properties will only be updated when `IsProportional` is set to true by the User.

- `width` Dependency Correction:
Corrected a copy-paste error where Width was incorrectly dependent on `HeadLength`. 
The Width now correctly depends on HeadWidth.

These updates ensure the properties behave as expected and align with user settings.

### Testing:
    Verified that setting IsProportional to false no longer affects HeadLength and HeadWidth.
    Confirmed that Width now properly depends on HeadWidth.