### PR TITLE
Fix Filled arrow head ignores visibility

### DIFF
--- a/src/Arrow.Avalonia/Controls/Arrow.axaml.cs
+++ b/src/Arrow.Avalonia/Controls/Arrow.axaml.cs
@@ -251,7 +251,7 @@ public partial class Arrow : UserControl
         s.ArrowLineHeadRight.StartPoint = headPoints.Right;
         s.ArrowLineHeadRight.EndPoint = headPoints.Top;
 
-        s.TrianglePath.IsVisible = s.IsFilled;
+        s.TrianglePath.IsVisible = s.IsVisible && s.IsFilled;
 
         if (s.IsFilled)
         {


### PR DESCRIPTION
Changes to address the issue #4 

The filled head would still be displayed even when `IsVisible=False`.

### Changes:
`TrianglePath` representing the arrow filled head takes into consideration if the arrow is visible or not.

### Testing:
`IsVisible=False` allows updates to to the Arrow settings, but no longer displays anything.